### PR TITLE
feat(api): Add endpoint execution-details/webhook to get webhook status

### DIFF
--- a/apps/api/src/app/execution-details/dtos/get-webhook-status-request.dto.ts
+++ b/apps/api/src/app/execution-details/dtos/get-webhook-status-request.dto.ts
@@ -1,0 +1,7 @@
+import { IsDefined, IsMongoId, IsString } from 'class-validator';
+
+export class GetWebhookStatusRequestDto {
+  @IsDefined()
+  @IsString()
+  transactionId: string;
+}

--- a/apps/api/src/app/execution-details/e2e/get-webhook-status.e2e.ts
+++ b/apps/api/src/app/execution-details/e2e/get-webhook-status.e2e.ts
@@ -1,0 +1,53 @@
+import { ExecutionDetailsRepository, SubscriberEntity } from '@novu/dal';
+import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum, StepTypeEnum } from '@novu/shared';
+import { UserSession, SubscribersService } from '@novu/testing';
+import axios from 'axios';
+import { expect } from 'chai';
+
+const axiosInstance = axios.create();
+
+describe('Execution details - Get webhook details by transaction id - /v1/execution-details/webhook/:transactionId (GET)', function () {
+  let session: UserSession;
+  const executionDetailsRepository: ExecutionDetailsRepository = new ExecutionDetailsRepository();
+  let subscriber: SubscriberEntity;
+  let subscriberService: SubscribersService;
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+    subscriberService = new SubscribersService(session.organization._id, session.environment._id);
+    subscriber = await subscriberService.createSubscriber();
+  });
+
+  it('should get webhook executation details by transactionId', async function () {
+    const transactionId = 'transactionId';
+    const detail = await executionDetailsRepository.create({
+      _jobId: ExecutionDetailsRepository.createObjectId(),
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      _notificationId: ExecutionDetailsRepository.createObjectId(),
+      _notificationTemplateId: ExecutionDetailsRepository.createObjectId(),
+      _subscriberId: subscriber._id,
+      providerId: '',
+      transactionId: 'transactionId',
+      channel: StepTypeEnum.EMAIL,
+      detail: '',
+      source: ExecutionDetailsSourceEnum.WEBHOOK,
+      status: ExecutionDetailsStatusEnum.SUCCESS,
+      isTest: false,
+      isRetry: false,
+    });
+
+    const {
+      data: { data },
+    } = await axiosInstance.get(`${session.serverUrl}/v1/execution-details/webook?transactionId=${transactionId}`, {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    });
+    const responseDetail = data[0];
+    expect(responseDetail.transactionId).to.equal(transactionId);
+    expect(responseDetail.channel).to.equal(detail.channel);
+    expect(responseDetail._id).to.equal(detail._id);
+  });
+});

--- a/apps/api/src/app/execution-details/execution-details.controller.ts
+++ b/apps/api/src/app/execution-details/execution-details.controller.ts
@@ -6,15 +6,17 @@ import { UserSession } from '../shared/framework/user.decorator';
 import { JwtAuthGuard } from '../auth/framework/auth.guard';
 import { ExternalApiAccessible } from '../auth/framework/external-api.decorator';
 import { GetExecutionDetails, GetExecutionDetailsCommand } from './usecases/get-execution-details';
+import { GetWebhookStatus, GetWebhookStatusCommand } from './usecases/get-webhook-status';
 import { ApiResponse } from '../shared/framework/response.decorator';
 import { ExecutionDetailsRequestDto } from './dtos/execution-details-request.dto';
+import { GetWebhookStatusRequestDto } from './dtos/get-webhook-status-request.dto';
 
 @Controller('/execution-details')
 @UseInterceptors(ClassSerializerInterceptor)
 @UseGuards(JwtAuthGuard)
 @ApiTags('Execution Details')
 export class ExecutionDetailsController {
-  constructor(private getExecutionDetails: GetExecutionDetails) {}
+  constructor(private getExecutionDetails: GetExecutionDetails, private getWebhookStatus: GetWebhookStatus) {}
 
   @Get('/')
   @ApiOperation({
@@ -33,6 +35,26 @@ export class ExecutionDetailsController {
         userId: user._id,
         notificationId: query.notificationId,
         subscriberId: query.subscriberId,
+      })
+    );
+  }
+
+  @Get('/webhook')
+  @ApiOperation({
+    summary: 'Get webhook status details',
+  })
+  @ApiResponse(ExecutionDetailsResponseDto, 200, true)
+  @ExternalApiAccessible()
+  async getExecutionDetailsForTransaction(
+    @UserSession() user: IJwtPayload,
+    @Query() query: GetWebhookStatusRequestDto
+  ): Promise<ExecutionDetailsResponseDto[]> {
+    return this.getWebhookStatus.execute(
+      GetWebhookStatusCommand.create({
+        transactionId: query.transactionId,
+        userId: user._id,
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
       })
     );
   }

--- a/apps/api/src/app/execution-details/usecases/get-webhook-status/get-webhook-status.command.ts
+++ b/apps/api/src/app/execution-details/usecases/get-webhook-status/get-webhook-status.command.ts
@@ -1,0 +1,7 @@
+import { EnvironmentWithUserCommand } from '@novu/application-generic';
+import { IsDefined } from 'class-validator';
+
+export class GetWebhookStatusCommand extends EnvironmentWithUserCommand {
+  @IsDefined()
+  transactionId: string;
+}

--- a/apps/api/src/app/execution-details/usecases/get-webhook-status/get-webhook-status.usecase.ts
+++ b/apps/api/src/app/execution-details/usecases/get-webhook-status/get-webhook-status.usecase.ts
@@ -1,0 +1,12 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ExecutionDetailsEntity, ExecutionDetailsRepository } from '@novu/dal';
+import { GetWebhookStatusCommand } from './get-webhook-status.command';
+
+@Injectable()
+export class GetWebhookStatus {
+  constructor(private executionDetailsRepository: ExecutionDetailsRepository) {}
+
+  async execute(command: GetWebhookStatusCommand): Promise<ExecutionDetailsEntity[]> {
+    return this.executionDetailsRepository.findByTransactionId(command.transactionId, command.environmentId);
+  }
+}

--- a/apps/api/src/app/execution-details/usecases/get-webhook-status/index.ts
+++ b/apps/api/src/app/execution-details/usecases/get-webhook-status/index.ts
@@ -1,0 +1,2 @@
+export { GetWebhookStatus } from './get-webhook-status.usecase';
+export { GetWebhookStatusCommand } from './get-webhook-status.command';

--- a/apps/api/src/app/execution-details/usecases/index.ts
+++ b/apps/api/src/app/execution-details/usecases/index.ts
@@ -1,5 +1,6 @@
 import { BulkCreateExecutionDetails, CreateExecutionDetails } from '@novu/application-generic';
 
 import { GetExecutionDetails } from './get-execution-details';
+import { GetWebhookStatus } from './get-webhook-status';
 
-export const USE_CASES = [CreateExecutionDetails, BulkCreateExecutionDetails, GetExecutionDetails];
+export const USE_CASES = [CreateExecutionDetails, BulkCreateExecutionDetails, GetExecutionDetails, GetWebhookStatus];

--- a/libs/dal/src/repositories/execution-details/execution-details.repository.ts
+++ b/libs/dal/src/repositories/execution-details/execution-details.repository.ts
@@ -44,4 +44,15 @@ export class ExecutionDetailsRepository extends BaseRepository<
       _notificationId: notificationId,
     });
   }
+
+  /**
+   * Activity feed might need to retrieve all the executions of a notification.
+   */
+  public async findByTransactionId(transactionId: string, environmentId: string) {
+    return await this.find({
+      transactionId: transactionId,
+      _environmentId: environmentId,
+      source: 'Webhook',
+    });
+  }
 }


### PR DESCRIPTION
### What change does this PR introduce?

Add a new endpoint to get webhook status by transactionId

```
localhost:3000/v1/execution-details/webhook?transactionId=b81fd192-8632-4a66-8866-df7bf2b73c4c
```

### Why was this change needed?

Access webhook status by transactionId

### Other information (Screenshots)

![image](https://github.com/vocedm/novu/assets/23130033/f71ed77d-b269-44ea-8e63-eaa680ef8361)

