### PR TITLE
feat(api): Get webhook status by batch of transactionsIds

### DIFF
--- a/apps/api/src/app/execution-details/dtos/get-webhook-status-request.dto.ts
+++ b/apps/api/src/app/execution-details/dtos/get-webhook-status-request.dto.ts
@@ -1,7 +1,9 @@
-import { IsDefined, IsArray, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsArray, IsString } from 'class-validator';
 
 export class GetWebhookStatusRequestDto {
-  @IsDefined()
+  @ApiProperty()
+  @IsOptional()
   @IsArray()
   @IsString({ each: true })
   transactionId: string[];

--- a/apps/api/src/app/execution-details/dtos/get-webhook-status-request.dto.ts
+++ b/apps/api/src/app/execution-details/dtos/get-webhook-status-request.dto.ts
@@ -1,7 +1,8 @@
-import { IsDefined, IsMongoId, IsString } from 'class-validator';
+import { IsDefined, IsArray, IsString } from 'class-validator';
 
 export class GetWebhookStatusRequestDto {
   @IsDefined()
-  @IsString()
-  transactionId: string;
+  @IsArray()
+  @IsString({ each: true })
+  transactionId: string[];
 }

--- a/apps/api/src/app/execution-details/e2e/get-webhook-status.e2e.ts
+++ b/apps/api/src/app/execution-details/e2e/get-webhook-status.e2e.ts
@@ -12,7 +12,7 @@ describe('should get webhook details by transactionId - /executation-details/web
     await session.initialize();
   });
 
-  it('should not allow to update the integration with same identifier', async function () {
+  it('get webhook executation details by transactionId', async function () {
     const transactionId = 'transactionId';
     const detail = await executionDetailsRepository.create({
       _jobId: ExecutionDetailsRepository.createObjectId(),
@@ -35,7 +35,6 @@ describe('should get webhook details by transactionId - /executation-details/web
     };
 
     const { body } = await session.testAgent.get(`/v1/executation-details/webhook`).send(payload);
-    console.log(body);
     expect(body[0].transactionId).to.equal('transactionId');
   });
 });

--- a/apps/api/src/app/execution-details/e2e/get-webhook-status.e2e.ts
+++ b/apps/api/src/app/execution-details/e2e/get-webhook-status.e2e.ts
@@ -1,63 +1,41 @@
-/*
- * import { ExecutionDetailsRepository, SubscriberEntity } from '@novu/dal';
- * import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum, StepTypeEnum } from '@novu/shared';
- * import { UserSession, SubscribersService } from '@novu/testing';
- * import axios from 'axios';
- * import { expect } from 'chai';
- */
+import { ExecutionDetailsRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum, StepTypeEnum } from '@novu/shared';
 
-// const axiosInstance = axios.create();
+describe('should get webhook details by transactionId - /executation-details/webhook (GET)', function () {
+  let session: UserSession;
+  const executionDetailsRepository: ExecutionDetailsRepository = new ExecutionDetailsRepository();
 
-/*
- * describe('Execution details - Get webhook details by transaction id - /v1/execution-details/webhook/:transactionId (GET)', function () {
- *   let session: UserSession;
- *   const executionDetailsRepository: ExecutionDetailsRepository = new ExecutionDetailsRepository();
- *   let subscriber: SubscriberEntity;
- *   let subscriberService: SubscribersService;
- */
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
 
-/*
- *   beforeEach(async () => {
- *     session = new UserSession();
- *     await session.initialize();
- *     subscriberService = new SubscribersService(session.organization._id, session.environment._id);
- *     subscriber = await subscriberService.createSubscriber();
- *   });
- */
+  it('should not allow to update the integration with same identifier', async function () {
+    const transactionId = 'transactionId';
+    const detail = await executionDetailsRepository.create({
+      _jobId: ExecutionDetailsRepository.createObjectId(),
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      _notificationId: ExecutionDetailsRepository.createObjectId(),
+      _notificationTemplateId: ExecutionDetailsRepository.createObjectId(),
+      _subscriberId: ExecutionDetailsRepository.createObjectId(),
+      providerId: '',
+      transactionId: 'transactionId',
+      channel: StepTypeEnum.EMAIL,
+      detail: '',
+      source: ExecutionDetailsSourceEnum.WEBHOOK,
+      status: ExecutionDetailsStatusEnum.SUCCESS,
+      isTest: false,
+      isRetry: false,
+    });
+    const payload = {
+      transactionId: ['transactionId'],
+    };
 
-/*
- *   it('should get webhook executation details by transactionId', async function () {
- *     const transactionId = 'transactionId';
- *     const detail = await executionDetailsRepository.create({
- *       _jobId: ExecutionDetailsRepository.createObjectId(),
- *       _environmentId: session.environment._id,
- *       _organizationId: session.organization._id,
- *       _notificationId: ExecutionDetailsRepository.createObjectId(),
- *       _notificationTemplateId: ExecutionDetailsRepository.createObjectId(),
- *       _subscriberId: subscriber._id,
- *       providerId: '',
- *       transactionId: 'transactionId',
- *       channel: StepTypeEnum.EMAIL,
- *       detail: '',
- *       source: ExecutionDetailsSourceEnum.WEBHOOK,
- *       status: ExecutionDetailsStatusEnum.SUCCESS,
- *       isTest: false,
- *       isRetry: false,
- *     });
- */
-
-/*
- *     const {
- *       data: { data },
- *     } = await axiosInstance.get(`${session.serverUrl}/v1/execution-details/webook?transactionId=${transactionId}`, {
- *       headers: {
- *         authorization: `ApiKey ${session.apiKey}`,
- *       },
- *     });
- *     const responseDetail = data[0];
- *     expect(responseDetail.transactionId).to.equal(transactionId);
- *     expect(responseDetail.channel).to.equal(detail.channel);
- *     expect(responseDetail._id).to.equal(detail._id);
- *   });
- * });
- */
+    const { body } = await session.testAgent.get(`/v1/executation-details/webhook`).send(payload);
+    console.log(body);
+    expect(body[0].transactionId).to.equal('transactionId');
+  });
+});

--- a/apps/api/src/app/execution-details/e2e/get-webhook-status.e2e.ts
+++ b/apps/api/src/app/execution-details/e2e/get-webhook-status.e2e.ts
@@ -1,53 +1,63 @@
-import { ExecutionDetailsRepository, SubscriberEntity } from '@novu/dal';
-import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum, StepTypeEnum } from '@novu/shared';
-import { UserSession, SubscribersService } from '@novu/testing';
-import axios from 'axios';
-import { expect } from 'chai';
+/*
+ * import { ExecutionDetailsRepository, SubscriberEntity } from '@novu/dal';
+ * import { ExecutionDetailsSourceEnum, ExecutionDetailsStatusEnum, StepTypeEnum } from '@novu/shared';
+ * import { UserSession, SubscribersService } from '@novu/testing';
+ * import axios from 'axios';
+ * import { expect } from 'chai';
+ */
 
-const axiosInstance = axios.create();
+// const axiosInstance = axios.create();
 
-describe('Execution details - Get webhook details by transaction id - /v1/execution-details/webhook/:transactionId (GET)', function () {
-  let session: UserSession;
-  const executionDetailsRepository: ExecutionDetailsRepository = new ExecutionDetailsRepository();
-  let subscriber: SubscriberEntity;
-  let subscriberService: SubscribersService;
+/*
+ * describe('Execution details - Get webhook details by transaction id - /v1/execution-details/webhook/:transactionId (GET)', function () {
+ *   let session: UserSession;
+ *   const executionDetailsRepository: ExecutionDetailsRepository = new ExecutionDetailsRepository();
+ *   let subscriber: SubscriberEntity;
+ *   let subscriberService: SubscribersService;
+ */
 
-  beforeEach(async () => {
-    session = new UserSession();
-    await session.initialize();
-    subscriberService = new SubscribersService(session.organization._id, session.environment._id);
-    subscriber = await subscriberService.createSubscriber();
-  });
+/*
+ *   beforeEach(async () => {
+ *     session = new UserSession();
+ *     await session.initialize();
+ *     subscriberService = new SubscribersService(session.organization._id, session.environment._id);
+ *     subscriber = await subscriberService.createSubscriber();
+ *   });
+ */
 
-  it('should get webhook executation details by transactionId', async function () {
-    const transactionId = 'transactionId';
-    const detail = await executionDetailsRepository.create({
-      _jobId: ExecutionDetailsRepository.createObjectId(),
-      _environmentId: session.environment._id,
-      _organizationId: session.organization._id,
-      _notificationId: ExecutionDetailsRepository.createObjectId(),
-      _notificationTemplateId: ExecutionDetailsRepository.createObjectId(),
-      _subscriberId: subscriber._id,
-      providerId: '',
-      transactionId: 'transactionId',
-      channel: StepTypeEnum.EMAIL,
-      detail: '',
-      source: ExecutionDetailsSourceEnum.WEBHOOK,
-      status: ExecutionDetailsStatusEnum.SUCCESS,
-      isTest: false,
-      isRetry: false,
-    });
+/*
+ *   it('should get webhook executation details by transactionId', async function () {
+ *     const transactionId = 'transactionId';
+ *     const detail = await executionDetailsRepository.create({
+ *       _jobId: ExecutionDetailsRepository.createObjectId(),
+ *       _environmentId: session.environment._id,
+ *       _organizationId: session.organization._id,
+ *       _notificationId: ExecutionDetailsRepository.createObjectId(),
+ *       _notificationTemplateId: ExecutionDetailsRepository.createObjectId(),
+ *       _subscriberId: subscriber._id,
+ *       providerId: '',
+ *       transactionId: 'transactionId',
+ *       channel: StepTypeEnum.EMAIL,
+ *       detail: '',
+ *       source: ExecutionDetailsSourceEnum.WEBHOOK,
+ *       status: ExecutionDetailsStatusEnum.SUCCESS,
+ *       isTest: false,
+ *       isRetry: false,
+ *     });
+ */
 
-    const {
-      data: { data },
-    } = await axiosInstance.get(`${session.serverUrl}/v1/execution-details/webook?transactionId=${transactionId}`, {
-      headers: {
-        authorization: `ApiKey ${session.apiKey}`,
-      },
-    });
-    const responseDetail = data[0];
-    expect(responseDetail.transactionId).to.equal(transactionId);
-    expect(responseDetail.channel).to.equal(detail.channel);
-    expect(responseDetail._id).to.equal(detail._id);
-  });
-});
+/*
+ *     const {
+ *       data: { data },
+ *     } = await axiosInstance.get(`${session.serverUrl}/v1/execution-details/webook?transactionId=${transactionId}`, {
+ *       headers: {
+ *         authorization: `ApiKey ${session.apiKey}`,
+ *       },
+ *     });
+ *     const responseDetail = data[0];
+ *     expect(responseDetail.transactionId).to.equal(transactionId);
+ *     expect(responseDetail.channel).to.equal(detail.channel);
+ *     expect(responseDetail._id).to.equal(detail._id);
+ *   });
+ * });
+ */

--- a/apps/api/src/app/execution-details/execution-details.controller.ts
+++ b/apps/api/src/app/execution-details/execution-details.controller.ts
@@ -1,4 +1,4 @@
-import { ClassSerializerInterceptor, Controller, Get, Query, UseGuards, UseInterceptors } from '@nestjs/common';
+import { ClassSerializerInterceptor, Controller, Get, Query, UseGuards, UseInterceptors, Body } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { IJwtPayload } from '@novu/shared';
 import { ExecutionDetailsResponseDto } from '@novu/application-generic';
@@ -47,13 +47,11 @@ export class ExecutionDetailsController {
   @ExternalApiAccessible()
   async getExecutionDetailsForTransaction(
     @UserSession() user: IJwtPayload,
-    @Query() query: GetWebhookStatusRequestDto
+    @Body() body: GetWebhookStatusRequestDto
   ): Promise<ExecutionDetailsResponseDto[]> {
-    const transactionId = Array.isArray(query.transactionId) ? query.transactionId : [query.transactionId];
-
     return this.getWebhookStatus.execute(
       GetWebhookStatusCommand.create({
-        transactionId: transactionId,
+        transactionId: body.transactionId,
         userId: user._id,
         environmentId: user.environmentId,
         organizationId: user.organizationId,

--- a/apps/api/src/app/execution-details/execution-details.controller.ts
+++ b/apps/api/src/app/execution-details/execution-details.controller.ts
@@ -49,9 +49,11 @@ export class ExecutionDetailsController {
     @UserSession() user: IJwtPayload,
     @Query() query: GetWebhookStatusRequestDto
   ): Promise<ExecutionDetailsResponseDto[]> {
+    const transactionId = Array.isArray(query.transactionId) ? query.transactionId : [query.transactionId];
+
     return this.getWebhookStatus.execute(
       GetWebhookStatusCommand.create({
-        transactionId: query.transactionId,
+        transactionId: transactionId,
         userId: user._id,
         environmentId: user.environmentId,
         organizationId: user.organizationId,

--- a/apps/api/src/app/execution-details/usecases/get-webhook-status/get-webhook-status.command.ts
+++ b/apps/api/src/app/execution-details/usecases/get-webhook-status/get-webhook-status.command.ts
@@ -1,7 +1,9 @@
 import { EnvironmentWithUserCommand } from '@novu/application-generic';
-import { IsDefined } from 'class-validator';
+import { IsArray, IsString, IsDefined } from 'class-validator';
 
 export class GetWebhookStatusCommand extends EnvironmentWithUserCommand {
   @IsDefined()
-  transactionId: string;
+  @IsArray()
+  @IsString({ each: true })
+  transactionId: string[];
 }

--- a/libs/dal/src/repositories/execution-details/execution-details.repository.ts
+++ b/libs/dal/src/repositories/execution-details/execution-details.repository.ts
@@ -49,27 +49,19 @@ export class ExecutionDetailsRepository extends BaseRepository<
    * Activity feed might need to retrieve all the executions of a notification.
    */
   public async findByTransactionId(transactionId: string[], environmentId: string) {
-    console.log(transactionId);
-
     const match = { transactionId: { $in: transactionId } };
-    const sort = { createdAt: -1 };
+    const sort = { transactionId: 1, createdAt: -1 };
     const group = {
-      _id: '$_id',
-      transactionId: { $first: '$transactionId' },
+      _id: '$transactionId',
       webhookStatus: { $first: '$webhookStatus' },
       providerId: { $first: '$providerId' },
-      _messageId: { $first: '$_messageId' },
-      _notificationId: { $first: '$_notificationId' },
-      createAt: { $first: '$createdAt' },
+      createdAt: { $first: '$createdAt' },
     };
     const project = {
-      id: 0,
-      transactionId: 1,
-      webhookStatus: 1,
-      providerId: 1,
-      _messageId: 1,
-      _notificationId: 1,
-      createAt: 1,
+      transactionId: '$_id',
+      webhookStatus: '$webhookStatus',
+      providerId: '$providerId',
+      createdAt: '$createdAt',
     };
 
     const query = [
@@ -87,7 +79,6 @@ export class ExecutionDetailsRepository extends BaseRepository<
       },
     ];
 
-    console.log(query);
     const data = await this.aggregate(query);
 
     return data;

--- a/libs/dal/src/repositories/execution-details/execution-details.repository.ts
+++ b/libs/dal/src/repositories/execution-details/execution-details.repository.ts
@@ -48,11 +48,48 @@ export class ExecutionDetailsRepository extends BaseRepository<
   /**
    * Activity feed might need to retrieve all the executions of a notification.
    */
-  public async findByTransactionId(transactionId: string, environmentId: string) {
-    return await this.find({
-      transactionId: transactionId,
-      _environmentId: environmentId,
-      source: 'Webhook',
-    });
+  public async findByTransactionId(transactionId: string[], environmentId: string) {
+    console.log(transactionId);
+
+    const match = { transactionId: { $in: transactionId } };
+    const sort = { createdAt: -1 };
+    const group = {
+      _id: '$_id',
+      transactionId: { $first: '$transactionId' },
+      webhookStatus: { $first: '$webhookStatus' },
+      providerId: { $first: '$providerId' },
+      _messageId: { $first: '$_messageId' },
+      _notificationId: { $first: '$_notificationId' },
+      createAt: { $first: '$createdAt' },
+    };
+    const project = {
+      id: 0,
+      transactionId: 1,
+      webhookStatus: 1,
+      providerId: 1,
+      _messageId: 1,
+      _notificationId: 1,
+      createAt: 1,
+    };
+
+    const query = [
+      {
+        $match: match,
+      },
+      {
+        $sort: sort,
+      },
+      {
+        $group: group,
+      },
+      {
+        $project: project,
+      },
+    ];
+
+    console.log(query);
+    const data = await this.aggregate(query);
+
+    return data;
   }
 }


### PR DESCRIPTION
### What change does this PR introduce?

Change find webhook status to batch of transactionsIds to search

### Why was this change needed?

Allow make request to get webhook status by batchs

### Other information (Screenshots)

![image](https://github.com/vocedm/novu/assets/23130033/3d052229-eb6f-48e6-ba34-18f185939956)